### PR TITLE
Update termscp to v0.19.0

### DIFF
--- a/termscp/termscp.spec
+++ b/termscp/termscp.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:    termscp
-Version: 0.18.0
+Version: 0.19.0
 Release: %autorelease
 Summary: A feature-rich terminal SCP client
 License: MIT


### PR DESCRIPTION
Automated update of termscp spec from 0.18.0 to 0.19.0.