### PR TITLE
Update lazydocker to v0.24.3

### DIFF
--- a/lazydocker/lazydocker.spec
+++ b/lazydocker/lazydocker.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:       lazydocker
-Version: 0.24.2
+Version: 0.24.3
 Release:    %autorelease
 Summary:    The lazier way to manage everything docker
 License:    MIT


### PR DESCRIPTION
Automated update of lazydocker spec from 0.24.2 to 0.24.3.