### PR TITLE
Update lazygit to v0.62.1

### DIFF
--- a/lazygit/lazygit.spec
+++ b/lazygit/lazygit.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:       lazygit
-Version: 0.59.0
+Version: 0.62.1
 Release:    %autorelease
 Summary:    Simple, pragmatic TUI (Terminal UI) frontend for GIT
 License:    MIT


### PR DESCRIPTION
Automated update of lazygit spec from 0.59.0 to 0.62.1.