### PR TITLE
Update systemctl-tui to v0.6.0

### DIFF
--- a/systemctl-tui/systemctl-tui.spec
+++ b/systemctl-tui/systemctl-tui.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:    systemctl-tui
-Version: 0.5.1
+Version: 0.6.0
 Release: %autorelease
 Summary: A fast, simple TUI for interacting with systemd services and their logs.  
 License: MIT


### PR DESCRIPTION
Automated update of systemctl-tui spec from 0.5.1 to 0.6.0.